### PR TITLE
Add signedness experiment

### DIFF
--- a/src/bubbler/backend/colors/implication.rs
+++ b/src/bubbler/backend/colors/implication.rs
@@ -60,10 +60,25 @@ impl<L: Language> Implication<L> {
                 .generalize(&mut map)
                 .map_err(|e| format!("Failed to generalize LHS of implication: {}", e))?,
         };
+        let from_bound = map.len();
         let to_generalized = to
             .term
             .generalize(&mut map)
             .map_err(|e| format!("Failed to generalize RHS of implication: {}", e))?;
+
+        // `generalize` converts Term::Var → Term::Hole and records each mapping in
+        // `map`. Any variables in the consequent that weren't already in the
+        // antecedent get fresh entries — detected by map growing past `from_bound`.
+        // Those fresh holes have no binding in the egglog rule body, which egglog
+        // rejects as an unbound variable error.
+        if map.len() > from_bound {
+            return Err(format!(
+                "Consequent introduces variables not bound by antecedent: {} --> {}",
+                from_generalized.to_sexp(),
+                to_generalized.to_sexp()
+            ));
+        }
+
         Ok(Self {
             from: match from.clone() {
                 Condition::Predicate(_) => {
@@ -107,3 +122,4 @@ impl<L: Language> std::fmt::Display for Implication<L> {
         )
     }
 }
+

--- a/src/bubbler/backend/colors/implication.rs
+++ b/src/bubbler/backend/colors/implication.rs
@@ -46,6 +46,11 @@ impl<L: Language> From<Condition<L>> for Expr {
 pub struct Implication<L: Language> {
     pub from: Condition<L>,
     pub to: PredicateTerm<L>,
+    /// Number of true slots in the antecedent's PVec. More = weaker antecedent = more general.
+    /// Zero when not set (e.g. manually constructed implications).
+    pub pvec_ante_count: usize,
+    /// Number of true slots in the consequent's PVec. Fewer = stronger consequent = more informative.
+    pub pvec_cons_count: usize,
 }
 
 impl<L: Language> Implication<L> {
@@ -87,6 +92,8 @@ impl<L: Language> Implication<L> {
                 Condition::Term(_) => Condition::Term(from_generalized),
             },
             to: PredicateTerm::from_term(to_generalized),
+            pvec_ante_count: 0,
+            pvec_cons_count: 0,
         })
     }
 

--- a/src/bubbler/backend/mod.rs
+++ b/src/bubbler/backend/mod.rs
@@ -375,6 +375,81 @@ impl<L: Language> EgglogBackend<L> {
                 },
             }])
             .unwrap();
+
+        // Or idempotency: Or(P, P) = P. Merges the e-class of Or(a, a) with a
+        // so that idempotent Or predicates don't generate spurious candidates.
+        egraph
+            .run_program(vec![GenericCommand::Rule {
+                rule: GenericRule {
+                    span: span!(),
+                    head: GenericActions(vec![GenericAction::Union(
+                        span!(),
+                        call!(
+                            bubbler_defns::BASE_TERM.to_string(),
+                            vec![call!(
+                                "Or".to_string(),
+                                vec![var!("a".to_string()), var!("a".to_string())]
+                            )]
+                        ),
+                        call!(bubbler_defns::BASE_TERM.to_string(), vec![var!("a".to_string())]),
+                    )]),
+                    body: vec![GenericFact::Fact(call!(
+                        bubbler_defns::BASE_TERM.to_string(),
+                        vec![call!(
+                            "Or".to_string(),
+                            vec![var!("a".to_string()), var!("a".to_string())]
+                        )]
+                    ))],
+                    name: "or-idempotency".to_string(),
+                    ruleset: bubbler_defns::PROPAGATE_ANALYSIS_RULESET.to_string(),
+                },
+            }])
+            .unwrap();
+
+        // Conjunction elimination: And(P, Q) implies P, and And(P, Q) implies Q.
+        // These are logical tautologies; registering them lets the minimizer prune
+        // any candidate of the form And(P,Q)→P or And(P,Q)→Q immediately, and
+        // transitivity then chains to prune And(P,Q)→R whenever P→R is known.
+        for (rule_name, consequent_var) in [("and-elim-left", "a"), ("and-elim-right", "b")] {
+            egraph
+                .run_program(vec![GenericCommand::Rule {
+                    rule: GenericRule {
+                        span: span!(),
+                        head: GenericActions(vec![GenericAction::Expr(
+                            span!(),
+                            call!(
+                                bubbler_defns::IMPLIES_RELATION.to_string(),
+                                vec![
+                                    call!(
+                                        bubbler_defns::BASE_TERM.to_string(),
+                                        vec![call!(
+                                            "And".to_string(),
+                                            vec![
+                                                var!("a".to_string()),
+                                                var!("b".to_string())
+                                            ]
+                                        )]
+                                    ),
+                                    call!(
+                                        bubbler_defns::BASE_TERM.to_string(),
+                                        vec![var!(consequent_var.to_string())]
+                                    ),
+                                ]
+                            ),
+                        )]),
+                        body: vec![GenericFact::Fact(call!(
+                            bubbler_defns::BASE_TERM.to_string(),
+                            vec![call!(
+                                "And".to_string(),
+                                vec![var!("a".to_string()), var!("b".to_string())]
+                            )]
+                        ))],
+                        name: rule_name.to_string(),
+                        ruleset: bubbler_defns::PROPAGATE_ANALYSIS_RULESET.to_string(),
+                    },
+                }])
+                .unwrap();
+        }
     }
 
     /// Returns all predicates whose PVec is all-true over the current environment —
@@ -561,27 +636,28 @@ impl<L: Language> EgglogBackend<L> {
     pub fn register_implication(&mut self, implication: &Implication<L>) -> Result<(), String> {
         let lhs = &implication.from;
         let rhs = &implication.to;
-        self.egraph
-            .run_program(vec![GenericCommand::Rule {
-                rule: GenericRule {
-                    span: span!(),
-                    head: GenericActions(vec![GenericAction::Expr(
-                        span!(),
-                        // mark the LHS and RHS as implied if...
-                        call!(
-                            bubbler_defns::IMPLIES_RELATION.to_string(),
-                            vec![lhs.clone().into(), rhs.clone().into()]
-                        ),
-                    )]),
-                    // ...we can see that the LHS is in the egraph.
-                    body: vec![GenericFact::Fact(lhs.clone().into())],
-                    name: format!("{}", implication),
-                    ruleset: bubbler_defns::PROPAGATE_ANALYSIS_RULESET.to_string(),
-                },
-            }])
-            .map_err(|e| format!("Failed to register implication: {:?}", e).to_string())?;
 
-        Ok(())
+        let result = self.egraph.run_program(vec![GenericCommand::Rule {
+            rule: GenericRule {
+                span: span!(),
+                head: GenericActions(vec![GenericAction::Expr(
+                    span!(),
+                    call!(
+                        bubbler_defns::IMPLIES_RELATION.to_string(),
+                        vec![lhs.clone().into(), rhs.clone().into()]
+                    ),
+                )]),
+                body: vec![GenericFact::Fact(lhs.clone().into())],
+                name: format!("{}", implication),
+                ruleset: bubbler_defns::PROPAGATE_ANALYSIS_RULESET.to_string(),
+            },
+        }]);
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if format!("{:?}", e).contains("already present") => Ok(()),
+            Err(e) => Err(format!("Failed to register implication: {:?}", e)),
+        }
     }
 
     pub fn add_term(&mut self, term: Term<L>, with_cvec: bool) -> Result<EClassId, String> {
@@ -778,6 +854,23 @@ impl<L: Language> EgglogBackend<L> {
             Ok(_) => Ok(true),
             Err(egglog::Error::CheckError(_, _)) => Ok(false),
             Err(e) => Err(format!("Failed to check equality: {:?}", e)),
+        }
+    }
+
+    /// Print all facts currently in the `implies` relation, up to `limit`.
+    pub fn dump_implies(&mut self, limit: usize) {
+        let result = self.egraph.parse_and_run_program(
+            None,
+            &format!("(print-function {} {})", bubbler_defns::IMPLIES_RELATION, limit),
+        );
+        match result {
+            Ok(outputs) => {
+                eprintln!("[dump_implies] {} outputs:", outputs.len());
+                for o in &outputs {
+                    eprintln!("  {:?}", o);
+                }
+            }
+            Err(e) => eprintln!("[dump_implies] error: {:?}", e),
         }
     }
 

--- a/src/bubbler/backend/mod.rs
+++ b/src/bubbler/backend/mod.rs
@@ -377,6 +377,16 @@ impl<L: Language> EgglogBackend<L> {
             .unwrap();
     }
 
+    /// Returns all predicates whose PVec is all-true over the current environment —
+    /// i.e., predicates that hold unconditionally for any variable assignment.
+    pub fn get_axioms(&mut self) -> Vec<PredicateTerm<L>> {
+        self.get_pvec_map()
+            .into_iter()
+            .filter(|(pvec, _)| pvec.iter().all(|&b| b))
+            .flat_map(|(_, terms)| terms)
+            .collect()
+    }
+
     /// Returns a mapping from CVecs to terms in the egraph with those CVecs.
     pub fn get_cvec_map(&mut self) -> HashMap<CVec<L>, Vec<Term<L>>> {
         let result = self

--- a/src/bubbler/backend/mod.rs
+++ b/src/bubbler/backend/mod.rs
@@ -450,6 +450,219 @@ impl<L: Language> EgglogBackend<L> {
                 }])
                 .unwrap();
         }
+
+        // And-congruence (monotonicity): if P → P', then And(P,Q) → And(P',Q)
+        // and symmetrically And(P,Q) → And(P,Q').
+        // This lets the minimizer prune component-wise lattice weakenings like
+        // And(Gt a 0, X) → And(Ge a 0, X) once Gt→Ge is registered.
+        for (rule_name, (imp_lhs, imp_rhs, and_other, res_left, res_right)) in [
+            ("and-congruence-left",  ("p", "pprime", "q", "pprime", "q")),
+            ("and-congruence-right", ("q", "qprime", "p", "p",      "qprime")),
+        ] {
+            egraph
+                .run_program(vec![GenericCommand::Rule {
+                    rule: GenericRule {
+                        span: span!(),
+                        head: GenericActions(vec![GenericAction::Expr(
+                            span!(),
+                            call!(
+                                bubbler_defns::IMPLIES_RELATION.to_string(),
+                                vec![
+                                    // lhs: And(p, q)
+                                    call!(
+                                        bubbler_defns::BASE_TERM.to_string(),
+                                        vec![call!(
+                                            "And".to_string(),
+                                            vec![
+                                                var!("p".to_string()),
+                                                var!("q".to_string()),
+                                            ]
+                                        )]
+                                    ),
+                                    // rhs: And(res_left, res_right)
+                                    call!(
+                                        bubbler_defns::BASE_TERM.to_string(),
+                                        vec![call!(
+                                            "And".to_string(),
+                                            vec![
+                                                var!(res_left.to_string()),
+                                                var!(res_right.to_string()),
+                                            ]
+                                        )]
+                                    ),
+                                ]
+                            ),
+                        )]),
+                        body: vec![
+                            // implies(BaseTerm(imp_lhs), BaseTerm(imp_rhs))
+                            GenericFact::Fact(call!(
+                                bubbler_defns::IMPLIES_RELATION.to_string(),
+                                vec![
+                                    call!(
+                                        bubbler_defns::BASE_TERM.to_string(),
+                                        vec![var!(imp_lhs.to_string())]
+                                    ),
+                                    call!(
+                                        bubbler_defns::BASE_TERM.to_string(),
+                                        vec![var!(imp_rhs.to_string())]
+                                    ),
+                                ]
+                            )),
+                            // BaseTerm(And(p, q))  — ensures the And-predicate exists
+                            GenericFact::Fact(call!(
+                                bubbler_defns::BASE_TERM.to_string(),
+                                vec![call!(
+                                    "And".to_string(),
+                                    vec![
+                                        var!("p".to_string()),
+                                        var!("q".to_string()),
+                                    ]
+                                )]
+                            )),
+                        ],
+                        name: rule_name.to_string(),
+                        ruleset: bubbler_defns::PROPAGATE_ANALYSIS_RULESET.to_string(),
+                    },
+                }])
+                .unwrap();
+            let _ = and_other; // used via the res_left/res_right tuple
+        }
+
+        // And-introduction: if A → P and A → Q, and And(P,Q) exists as a predicate,
+        // then A → And(P,Q). This subsumes the and-congruence rules: And(P,Q) → And(P',Q)
+        // follows from and-elim-left (And(P,Q)→P), P→P' (lattice), transitivity, and-elim-right,
+        // and this rule. It also handles the case where the antecedent's components weaken
+        // through the lattice e.g. And(Lt(0,a), Eq(b,0)) → And(Ge(a,0), Eq(b,0)).
+        egraph
+            .run_program(vec![GenericCommand::Rule {
+                rule: GenericRule {
+                    span: span!(),
+                    head: GenericActions(vec![GenericAction::Expr(
+                        span!(),
+                        call!(
+                            bubbler_defns::IMPLIES_RELATION.to_string(),
+                            vec![
+                                var!("a".to_string()),
+                                call!(
+                                    bubbler_defns::BASE_TERM.to_string(),
+                                    vec![call!(
+                                        "And".to_string(),
+                                        vec![var!("p".to_string()), var!("q".to_string())]
+                                    )]
+                                ),
+                            ]
+                        ),
+                    )]),
+                    body: vec![
+                        GenericFact::Fact(call!(
+                            bubbler_defns::IMPLIES_RELATION.to_string(),
+                            vec![
+                                var!("a".to_string()),
+                                call!(
+                                    bubbler_defns::BASE_TERM.to_string(),
+                                    vec![var!("p".to_string())]
+                                ),
+                            ]
+                        )),
+                        GenericFact::Fact(call!(
+                            bubbler_defns::IMPLIES_RELATION.to_string(),
+                            vec![
+                                var!("a".to_string()),
+                                call!(
+                                    bubbler_defns::BASE_TERM.to_string(),
+                                    vec![var!("q".to_string())]
+                                ),
+                            ]
+                        )),
+                        GenericFact::Fact(call!(
+                            bubbler_defns::BASE_TERM.to_string(),
+                            vec![call!(
+                                "And".to_string(),
+                                vec![var!("p".to_string()), var!("q".to_string())]
+                            )]
+                        )),
+                    ],
+                    name: "and-intro".to_string(),
+                    ruleset: bubbler_defns::PROPAGATE_ANALYSIS_RULESET.to_string(),
+                },
+            }])
+            .unwrap();
+
+        // Reflexivity: every predicate in the egraph implies itself.
+        // Required so And-congruence can fire when one And-component is unchanged
+        // (e.g. And(Eq a 0, Gt b 0) → And(Eq a 0, Ge b 0) needs implies(Eq a 0, Eq a 0)).
+        egraph
+            .run_program(vec![GenericCommand::Rule {
+                rule: GenericRule {
+                    span: span!(),
+                    head: GenericActions(vec![GenericAction::Expr(
+                        span!(),
+                        call!(
+                            bubbler_defns::IMPLIES_RELATION.to_string(),
+                            vec![
+                                call!(bubbler_defns::BASE_TERM.to_string(), vec![var!("p".to_string())]),
+                                call!(bubbler_defns::BASE_TERM.to_string(), vec![var!("p".to_string())]),
+                            ]
+                        ),
+                    )]),
+                    body: vec![GenericFact::Fact(call!(
+                        bubbler_defns::BASE_TERM.to_string(),
+                        vec![var!("p".to_string())]
+                    ))],
+                    name: "reflexivity".to_string(),
+                    ruleset: bubbler_defns::PROPAGATE_ANALYSIS_RULESET.to_string(),
+                },
+            }])
+            .unwrap();
+
+        // Antisymmetry: if A → Ge(t, u) and A → Ge(u, t), then A → Eq(t, u).
+        // Collapses paired Ge-weakening rules (e.g. → Ge(t,0) and → Ge(0,t)) into
+        // the single stronger rule → Eq(t,0). Requires the language to have Ge and Eq
+        // operators (as with LLVM sign analysis).
+        egraph
+            .run_program(vec![GenericCommand::Rule {
+                rule: GenericRule {
+                    span: span!(),
+                    head: GenericActions(vec![GenericAction::Expr(
+                        span!(),
+                        call!(
+                            bubbler_defns::IMPLIES_RELATION.to_string(),
+                            vec![
+                                var!("a".to_string()),
+                                call!(
+                                    bubbler_defns::BASE_TERM.to_string(),
+                                    vec![call!("Eq".to_string(), vec![var!("t".to_string()), var!("u".to_string())])]
+                                ),
+                            ]
+                        ),
+                    )]),
+                    body: vec![
+                        GenericFact::Fact(call!(
+                            bubbler_defns::IMPLIES_RELATION.to_string(),
+                            vec![
+                                var!("a".to_string()),
+                                call!(
+                                    bubbler_defns::BASE_TERM.to_string(),
+                                    vec![call!("Ge".to_string(), vec![var!("t".to_string()), var!("u".to_string())])]
+                                ),
+                            ]
+                        )),
+                        GenericFact::Fact(call!(
+                            bubbler_defns::IMPLIES_RELATION.to_string(),
+                            vec![
+                                var!("a".to_string()),
+                                call!(
+                                    bubbler_defns::BASE_TERM.to_string(),
+                                    vec![call!("Ge".to_string(), vec![var!("u".to_string()), var!("t".to_string())])]
+                                ),
+                            ]
+                        )),
+                    ],
+                    name: "antisymmetry".to_string(),
+                    ruleset: bubbler_defns::PROPAGATE_ANALYSIS_RULESET.to_string(),
+                },
+            }])
+            .unwrap();
     }
 
     /// Returns all predicates whose PVec is all-true over the current environment —
@@ -637,6 +850,8 @@ impl<L: Language> EgglogBackend<L> {
         let lhs = &implication.from;
         let rhs = &implication.to;
 
+        // Register as a universally-quantified rule so future BaseTerm additions
+        // (via add_predicate after this call) also trigger the implication.
         let result = self.egraph.run_program(vec![GenericCommand::Rule {
             rule: GenericRule {
                 span: span!(),
@@ -654,10 +869,50 @@ impl<L: Language> EgglogBackend<L> {
         }]);
 
         match result {
-            Ok(_) => Ok(()),
-            Err(e) if format!("{:?}", e).contains("already present") => Ok(()),
-            Err(e) => Err(format!("Failed to register implication: {:?}", e)),
+            Ok(_) => {}
+            Err(e) if format!("{:?}", e).contains("already present") => {}
+            Err(e) => return Err(format!("Failed to register implication: {:?}", e)),
         }
+
+        // Also assert the concrete implies fact directly. Egglog's seminaive
+        // evaluation only fires rules on new delta facts, so if BaseTerm(lhs)
+        // was already present before the last run_implications call, the rule
+        // above will never trigger for it in subsequent calls. Asserting the
+        // fact directly puts it in the delta for the next run_implications call,
+        // allowing transitivity to chain on it immediately.
+        //
+        // Implications may be generalized (holes, e.g. Hole("?x")) or already
+        // concrete (vars, e.g. Var("x")). concretize() only handles the hole
+        // case, so fall back to the original term when it's already concrete.
+        let concrete_lhs: Expr = {
+            let concrete_term = match &implication.from {
+                Condition::Predicate(p) => p
+                    .term
+                    .concretize()
+                    .unwrap_or_else(|_| p.term.clone()),
+                Condition::Term(t) => t.concretize().unwrap_or_else(|_| t.clone()),
+            };
+            PredicateTerm::from_term(concrete_term).into()
+        };
+        let concrete_rhs: Expr = {
+            let concrete_term = implication
+                .to
+                .term
+                .concretize()
+                .unwrap_or_else(|_| implication.to.term.clone());
+            PredicateTerm::from_term(concrete_term).into()
+        };
+        self.egraph
+            .run_program(vec![GenericCommand::Action(GenericAction::Expr(
+                span!(),
+                call!(
+                    bubbler_defns::IMPLIES_RELATION.to_string(),
+                    vec![concrete_lhs, concrete_rhs]
+                ),
+            ))])
+            .map_err(|e| format!("Failed to assert implies fact: {:?}", e))?;
+
+        Ok(())
     }
 
     pub fn add_term(&mut self, term: Term<L>, with_cvec: bool) -> Result<EClassId, String> {
@@ -773,9 +1028,8 @@ impl<L: Language> EgglogBackend<L> {
 
     pub fn run_implications(&mut self) -> Result<(), String> {
         self.egraph
-            .run_program(vec![GenericCommand::RunSchedule(GenericSchedule::Repeat(
+            .run_program(vec![GenericCommand::RunSchedule(GenericSchedule::Saturate(
                 span!(),
-                7,
                 Box::new(GenericSchedule::Run(
                     span!(),
                     GenericRunConfig {

--- a/src/bubbler/identification/basic_match.rs
+++ b/src/bubbler/identification/basic_match.rs
@@ -68,15 +68,31 @@ impl<L: Language> Identification<L> for CvecMatch<L> {
     }
 }
 
+/// AxiomMatch finds predicates that are unconditionally true over the evaluation
+/// environment — those whose PVec is all-true. These are shape-based axioms
+/// like `abs(x) >= 0` that require no antecedent predicate.
+pub struct AxiomMatch<L: Language> {
+    _marker: std::marker::PhantomData<L>,
+}
+
+impl<L: Language> AxiomMatch<L> {
+    pub fn new() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<L: Language> Identification<L> for AxiomMatch<L> {
+    fn identify(&self, backend: &mut EgglogBackend<L>) -> Result<InferredFacts<L>, String> {
+        Ok(InferredFacts::Axioms(backend.get_axioms()))
+    }
+}
+
 /// PvecMatch finds likely candidates for _implications_ through pvec matching.
 /// Formally, two predicates with pvecs `p, q` are a match if
 /// `\forall i. p[i] => q[i]`. Like in the real world, implications in
 /// the forward directions do not guarantee implications in the reverse direction.
-///
-// NOTE: pvec matching only works for predicates. If you want to discover
-// predicates which hold for _any_ term, use a different matching strategy
-// (which I'll implement soon!).
-// TODO(@ninehusky): implement the above.
 #[allow(dead_code)]
 pub struct PvecMatch<L: Language> {
     cfg: IdentificationConfig,

--- a/src/bubbler/identification/basic_match.rs
+++ b/src/bubbler/identification/basic_match.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     bubbler::{Implication, InferredFacts, backend::EgglogBackend, schedule::Identification},
-    language::{CVec, Language, PVec, rewrite::Rewrite},
+    language::{CVec, Language, OpTrait, PVec, Term, rewrite::Rewrite},
 };
 
 use super::IdentificationConfig;
@@ -155,6 +155,14 @@ impl<L: Language> Identification<L> for PvecMatch<L> {
             }
         }
 
+        // Build a reverse map from predicate terms to their PVecs for the
+        // extended Or-weakening filter (step 2).
+        let term_to_pvec: std::collections::HashMap<&crate::language::PredicateTerm<L>, &PVec> =
+            pvec_map
+                .iter()
+                .flat_map(|(pvec, terms)| terms.iter().map(move |t| (t, pvec)))
+                .collect();
+
         let mut candidates = vec![];
         for (from, to) in matching_pvecs {
             let from_terms = pvec_map.get(&from).unwrap();
@@ -162,13 +170,77 @@ impl<L: Language> Identification<L> for PvecMatch<L> {
 
             for from_term in from_terms {
                 for to_term in to_terms {
-                    let implication =
-                        Implication::new(from_term.clone().into(), to_term.clone()).unwrap();
-                    candidates.push(implication);
+                    // Skip trivially true implications:
+                    //
+                    // Syntactic: And(P,Q)→P/Q and P→Or(P,Q)/Q→Or(P,Q).
+                    //
+                    // PVec-lattice: P → Or(Q, R) when pvec(P) ⊆ pvec(Q) or
+                    // pvec(P) ⊆ pvec(R). These are derivable through the lattice
+                    // even when P is not literally a component of Or.
+                    let syntactic_trivial = match (&from_term.term, &to_term.term) {
+                        (Term::Call(f, args), _) if f.is_conjunction() => {
+                            args.iter().any(|a| a == &to_term.term)
+                        }
+                        (_, Term::Call(t, args)) if t.is_disjunction() => {
+                            args.iter().any(|a| a == &from_term.term)
+                        }
+                        _ => false,
+                    };
+
+                    let pvec_trivial = if let Term::Call(t, or_args) = &to_term.term {
+                        if t.is_disjunction() && or_args.len() == 2 {
+                            let p = crate::language::PredicateTerm::from_term(or_args[0].clone());
+                            let q = crate::language::PredicateTerm::from_term(or_args[1].clone());
+                            let pv_p = term_to_pvec.get(&p);
+                            let pv_q = term_to_pvec.get(&q);
+                            // P → Or(Q,R) is trivial if pvec(P) ⊆ pvec(Q) or pvec(P) ⊆ pvec(R)
+                            pv_p.map_or(false, |pq| {
+                                from.iter().zip(pq.iter()).all(|(a, b)| !*a || *b)
+                            }) || pv_q.map_or(false, |pq| {
+                                from.iter().zip(pq.iter()).all(|(a, b)| !*a || *b)
+                            })
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+
+                    // Skip And(P,Q)→R when all of R's pattern holes are covered
+                    // by P alone or Q alone — dominated by the single-antecedent P→R
+                    // or Q→R, which the minimizer would already have or will find.
+                    let and_dominated = if let Term::Call(f, and_args) = &from_term.term {
+                        if f.is_conjunction() && and_args.len() == 2 {
+                            let r_holes = to_term.term.holes();
+                            let p_holes = and_args[0].holes();
+                            let q_holes = and_args[1].holes();
+                            let covered_by_p = r_holes.iter().all(|h| p_holes.contains(h));
+                            let covered_by_q = r_holes.iter().all(|h| q_holes.contains(h));
+                            covered_by_p || covered_by_q
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+
+                    if syntactic_trivial || pvec_trivial || and_dominated {
+                        continue;
+                    }
+
+                    // Skip implications where the consequent introduces variables
+                    // not bound by the antecedent — those are structurally
+                    // unregisterable in egglog (need a universe relation).
+                    if let Ok(implication) =
+                        Implication::new(from_term.clone().into(), to_term.clone())
+                    {
+                        candidates.push(implication);
+                    }
                 }
             }
         }
 
+        eprintln!("[pvec_match] {} implication candidates", candidates.len());
         Ok(InferredFacts::Implications(candidates))
     }
 }

--- a/src/bubbler/identification/basic_match.rs
+++ b/src/bubbler/identification/basic_match.rs
@@ -209,13 +209,15 @@ impl<L: Language> Identification<L> for PvecMatch<L> {
                     // Skip And(P,Q)→R when all of R's pattern holes are covered
                     // by P alone or Q alone — dominated by the single-antecedent P→R
                     // or Q→R, which the minimizer would already have or will find.
+                    // PvecMatch operates on concrete terms (Term::Var, not Term::Hole),
+                    // so use .vars() not .holes() to get variable names.
                     let and_dominated = if let Term::Call(f, and_args) = &from_term.term {
                         if f.is_conjunction() && and_args.len() == 2 {
-                            let r_holes = to_term.term.holes();
-                            let p_holes = and_args[0].holes();
-                            let q_holes = and_args[1].holes();
-                            let covered_by_p = r_holes.iter().all(|h| p_holes.contains(h));
-                            let covered_by_q = r_holes.iter().all(|h| q_holes.contains(h));
+                            let r_vars = to_term.term.vars();
+                            let p_vars = and_args[0].vars();
+                            let q_vars = and_args[1].vars();
+                            let covered_by_p = r_vars.iter().all(|v| p_vars.contains(v));
+                            let covered_by_q = r_vars.iter().all(|v| q_vars.contains(v));
                             covered_by_p || covered_by_q
                         } else {
                             false
@@ -231,9 +233,11 @@ impl<L: Language> Identification<L> for PvecMatch<L> {
                     // Skip implications where the consequent introduces variables
                     // not bound by the antecedent — those are structurally
                     // unregisterable in egglog (need a universe relation).
-                    if let Ok(implication) =
+                    if let Ok(mut implication) =
                         Implication::new(from_term.clone().into(), to_term.clone())
                     {
+                        implication.pvec_ante_count = from.iter().filter(|&&b| b).count();
+                        implication.pvec_cons_count = to.iter().filter(|&&b| b).count();
                         candidates.push(implication);
                     }
                 }
@@ -465,6 +469,8 @@ pub mod cond_cvec_match_test {
                     LLVMLangOp::Neq,
                     vec![Term::Var("x".into()), Term::Var("y".into())],
                 )),
+                pvec_ante_count: 0,
+                pvec_cons_count: 0,
             })
             .unwrap();
 

--- a/src/bubbler/identification/mod.rs
+++ b/src/bubbler/identification/mod.rs
@@ -1,7 +1,7 @@
 mod basic_match;
 mod bubbler_match;
 
-pub use basic_match::{ConditionalCvecMatch, CvecMatch, PvecMatch};
+pub use basic_match::{AxiomMatch, ConditionalCvecMatch, CvecMatch, PvecMatch};
 
 /// Describes the kind fact that is being identified.
 #[allow(dead_code)]

--- a/src/bubbler/minimization/basic_minimize.rs
+++ b/src/bubbler/minimization/basic_minimize.rs
@@ -222,10 +222,13 @@ impl<'a, L: Language> Minimization<L> for BasicImplicationMinimize<'a, L> {
         let InferredFacts::Implications(mut candidates) = candidates else {
             return Err("BasicImplicationMinimize only supports implication minimization.".into());
         };
+        // Sort ascending so pop() yields the highest-scoring (most informative)
+        // implication first. More informative = weaker antecedent + stronger
+        // consequent = should be registered first to subsume weaker variants.
         candidates.sort_by(|a, b| {
             let score_a = (self.score_fn)(a);
             let score_b = (self.score_fn)(b);
-            score_b.cmp(&score_a)
+            score_a.cmp(&score_b)
         });
 
         let mut chosen: Vec<Implication<L>> = self.existing.clone();
@@ -234,7 +237,10 @@ impl<'a, L: Language> Minimization<L> for BasicImplicationMinimize<'a, L> {
         // it would trigger an egglog "already present" panic.
         candidates.retain(|c| !chosen.contains(c));
 
-        eprintln!("[minimizer] {} candidates before minimization", candidates.len());
+        eprintln!("[minimizer] {} candidates before minimization:", candidates.len());
+        for c in &candidates {
+            eprintln!("  PRE  {}", c);
+        }
 
         for imp in candidates.iter() {
             let pre = imp.lhs_concrete();
@@ -242,6 +248,11 @@ impl<'a, L: Language> Minimization<L> for BasicImplicationMinimize<'a, L> {
             backend.add_predicate(pre.clone(), false).unwrap();
             backend.add_predicate(post.clone(), false).unwrap();
         }
+
+        // Apply any registered rewrites to the concrete candidate terms so that
+        // e.g. commutativity (Mul a b ~> Mul b a) unifies the symmetric forms
+        // before implication minimization begins.
+        backend.run_rewrites().unwrap();
 
         // 2. Iteratively add implications and remove redundant ones.
         let mut iter = 0usize;

--- a/src/bubbler/minimization/basic_minimize.rs
+++ b/src/bubbler/minimization/basic_minimize.rs
@@ -230,6 +230,12 @@ impl<'a, L: Language> Minimization<L> for BasicImplicationMinimize<'a, L> {
 
         let mut chosen: Vec<Implication<L>> = self.existing.clone();
 
+        // Drop any candidate that is already in the known-good set — re-registering
+        // it would trigger an egglog "already present" panic.
+        candidates.retain(|c| !chosen.contains(c));
+
+        eprintln!("[minimizer] {} candidates before minimization", candidates.len());
+
         for imp in candidates.iter() {
             let pre = imp.lhs_concrete();
             let post = imp.rhs_concrete();
@@ -238,19 +244,32 @@ impl<'a, L: Language> Minimization<L> for BasicImplicationMinimize<'a, L> {
         }
 
         // 2. Iteratively add implications and remove redundant ones.
+        let mut iter = 0usize;
         while let Some(selected) = candidates.pop() {
+            iter += 1;
+            eprintln!("[minimizer] iter {iter}: registering: {selected}  ({} remaining)", candidates.len());
             chosen.push(selected.clone());
+
+            eprintln!("[minimizer]   register_implication...");
             backend.register_implication(&selected).unwrap();
 
+            eprintln!("[minimizer]   run_implications...");
             backend.run_implications().unwrap();
 
-            // Remove redundant candidates.
+            if iter <= 2 {
+                eprintln!("[minimizer]   implies relation after iter {iter}:");
+                backend.dump_implies(30);
+            }
+
+            eprintln!("[minimizer]   pruning...");
+            let before = candidates.len();
             candidates.retain(|imp| {
                 let pre = imp.lhs_concrete();
                 let post = imp.rhs_concrete();
 
                 !backend.is_implied(&pre, &post).unwrap()
             });
+            eprintln!("[minimizer]   pruned {} → {} candidates", before, candidates.len());
         }
 
         // 3. Only add the new rules.

--- a/src/bubbler/minimization/mod.rs
+++ b/src/bubbler/minimization/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bubbler::{Condition, Implication},
-    language::{Language, Rewrite, Term},
+    language::{Language, OpTrait, Rewrite, Term},
 };
 
 mod basic_minimize;
@@ -20,6 +20,31 @@ pub mod score_fns {
 
     pub mod implication_score_fns {
         use super::*;
+
+        /// Score by PVec-based subsumption order: weak antecedent + strong consequent first.
+        /// Higher score = more general antecedent (many true slots) AND more informative
+        /// consequent (few true slots) = should be registered first so it subsumes weaker
+        /// variants. Falls back to AST size for implications without PVec counts.
+        pub fn pvec_strength<'a, L: Language>() -> Box<ImplicationScoreFn<'a, L>> {
+            Box::new(|imp: &Implication<L>| {
+                let base = if imp.pvec_ante_count > 0 || imp.pvec_cons_count > 0 {
+                    imp.pvec_ante_count as i64 - imp.pvec_cons_count as i64
+                } else {
+                    0
+                };
+                // Heavily penalize And-headed consequents (component-wise weakenings
+                // like And(P,Q)→And(P',Q)). The and-intro axiom will derive these
+                // once individual component implications are registered, so they
+                // should be processed last — they'll be pruned from candidates by
+                // the retain step before ever being popped into chosen.
+                let and_penalty: i64 = match &imp.to.term {
+                    Term::Call(op, _) if op.is_conjunction() => -1_000_000,
+                    _ => 0,
+                };
+                base + and_penalty
+            })
+        }
+
         pub fn prioritize_vars<'a, L: Language>() -> Box<ImplicationScoreFn<'a, L>> {
             fn cost<L: Language>(term: &Term<L>) -> i64 {
                 match term {
@@ -38,9 +63,7 @@ pub mod score_fns {
                     Condition::Predicate(p) => &p.term,
                     Condition::Term(t) => t,
                 };
-                let lhs_cost = cost(lhs_term);
-                let rhs_cost = cost(&imp.to.term);
-                lhs_cost + rhs_cost
+                cost(lhs_term) + cost(&imp.to.term)
             })
         }
     }

--- a/src/bubbler/mod.rs
+++ b/src/bubbler/mod.rs
@@ -95,7 +95,7 @@ impl<L: Language> Bubbler<L> {
         .identify(&mut backend)
         .unwrap();
 
-        let score_fn = implication_score_fns::prioritize_vars();
+        let score_fn = implication_score_fns::pvec_strength();
 
         // 4. Using what we know, minimize the candidates to only keep the best ones.
         let minimizer: BasicImplicationMinimize<L> =

--- a/src/bubbler/mod.rs
+++ b/src/bubbler/mod.rs
@@ -1,6 +1,7 @@
 use backend::EgglogBackend;
 use identification::{
-    ConditionalCvecMatch, CvecMatch, IdentificationConfig, IdentificationMode, PvecMatch,
+    AxiomMatch, ConditionalCvecMatch, CvecMatch, IdentificationConfig, IdentificationMode,
+    PvecMatch,
 };
 use minimization::BasicImplicationMinimize;
 use minimization::score_fns::implication_score_fns;
@@ -28,6 +29,7 @@ type ImplicationFacts<L> = InferredFacts<L>;
 pub enum InferredFacts<L: Language> {
     Implications(Vec<Implication<L>>),
     Rewrites(Vec<Rewrite<L>>),
+    Axioms(Vec<PredicateTerm<L>>),
 }
 
 pub struct BubblerConfig<L: Language> {
@@ -106,6 +108,23 @@ impl<L: Language> Bubbler<L> {
         };
 
         InferredFacts::Implications(imps)
+    }
+
+    /// Find all predicates in `wkld` that are unconditionally true over the
+    /// evaluation environment (all-true PVec). These are shape-based axioms
+    /// like `abs(x) >= 0` that hold regardless of variable values.
+    pub fn find_axioms(&self, wkld: &Workload) -> InferredFacts<L> {
+        let mut backend = self.new_backend();
+
+        let enumerator = BasicEnumerate::new(enumeration::EnumerationConfig {
+            mode: enumeration::EnumerationMode::Predicates,
+            evaluate: true,
+        });
+        enumerator
+            .enumerate_bubbler(&mut backend, wkld.clone())
+            .unwrap();
+
+        AxiomMatch::new().identify(&mut backend).unwrap()
     }
 
     /// Using the Bubbler's current inferred rules and implications,

--- a/src/language/mod.rs
+++ b/src/language/mod.rs
@@ -26,6 +26,12 @@ pub trait OpTrait: Clone + Debug + PartialEq + Eq {
     fn arity(&self) -> usize;
 
     fn name(&self) -> &'static str;
+
+    /// True if this operator is logical conjunction (AND) over predicate arguments.
+    fn is_conjunction(&self) -> bool { false }
+
+    /// True if this operator is logical disjunction (OR) over predicate arguments.
+    fn is_disjunction(&self) -> bool { false }
 }
 
 pub trait Language: Clone + Debug + PartialEq + Eq {

--- a/src/language/term.rs
+++ b/src/language/term.rs
@@ -79,6 +79,22 @@ impl<L: Language> Term<L> {
         }
     }
 
+    pub fn holes(&self) -> Vec<String> {
+        let mut h = vec![];
+        match self {
+            Term::Hole(name) => h.push(name.clone()),
+            Term::Var(_) | Term::Const(_) => {}
+            Term::Call(_, children) => {
+                for child in children {
+                    h.extend(child.holes());
+                }
+            }
+        }
+        h.sort();
+        h.dedup();
+        h
+    }
+
     pub fn vars(&self) -> Vec<String> {
         let mut vars = vec![];
         match self {

--- a/src/language/vectors/pvec.rs
+++ b/src/language/vectors/pvec.rs
@@ -12,6 +12,46 @@ impl PVec {
     ///
     /// This is the core check used during implication discovery.
     pub fn implies(&self, other: &PVec) -> bool {
-        self.iter().zip(other.iter()).all(|(p, q)| !(*p) && !*q)
+        self.iter().zip(other.iter()).all(|(p, q)| !(*p) || *q)
+    }
+
+    pub fn is_tautology(&self) -> bool {
+        self.iter().all(|b| *b)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pvec(vals: &[bool]) -> PVec {
+        vals.iter().cloned().collect()
+    }
+
+    #[test]
+    fn implies_truth_table() {
+        // p=F, q=F: F→F = true
+        assert!(pvec(&[false]).implies(&pvec(&[false])));
+        // p=F, q=T: F→T = true
+        assert!(pvec(&[false]).implies(&pvec(&[true])));
+        // p=T, q=T: T→T = true
+        assert!(pvec(&[true]).implies(&pvec(&[true])));
+        // p=T, q=F: T→F = false
+        assert!(!pvec(&[true]).implies(&pvec(&[false])));
+    }
+
+    #[test]
+    fn implies_mixed_vec() {
+        // [T,F] implies [T,T]: slot 0 ok (T→T), slot 1 ok (F→T)
+        assert!(pvec(&[true, false]).implies(&pvec(&[true, true])));
+        // [T,T] does NOT imply [T,F]: slot 1 fails (T→F)
+        assert!(!pvec(&[true, true]).implies(&pvec(&[true, false])));
+    }
+
+    #[test]
+    fn is_tautology() {
+        assert!(pvec(&[true, true, true]).is_tautology());
+        assert!(!pvec(&[true, false, true]).is_tautology());
+        assert!(!pvec(&[false, false]).is_tautology());
     }
 }

--- a/src/test_langs/llvm.rs
+++ b/src/test_langs/llvm.rs
@@ -72,8 +72,12 @@ impl OpTrait for LLVMLangOp {
         }
     }
 
-    fn is_conjunction(&self) -> bool { matches!(self, LLVMLangOp::And) }
-    fn is_disjunction(&self) -> bool { matches!(self, LLVMLangOp::Or) }
+    fn is_conjunction(&self) -> bool {
+        matches!(self, LLVMLangOp::And)
+    }
+    fn is_disjunction(&self) -> bool {
+        matches!(self, LLVMLangOp::Or)
+    }
 }
 
 impl Display for LLVMLangOp {
@@ -477,7 +481,16 @@ mod tests {
         let sym_and_preds = Workload::new(&["(And P Q)"])
             .plug("P", &x_preds)
             .plug("Q", &y_preds);
-        let sym_wkld = sym_atom_preds.append(sym_and_preds);
+        // Include (SIGN (Neg x) 0) so find_rewrites discovers Neg-flip equivalences:
+        // Gt(Neg x, 0) ↔ Lt(x, 0), Ge(Neg x, 0) ↔ Ge(0, x), Eq(Neg x, 0) ↔ Eq(x, 0).
+        let neg_preds = Workload::new(&["(SIGN (Neg x) 0)"]).plug("SIGN", &sign_ops);
+        // Include (SIGN (Abs x) 0) and (SIGN 0 (Abs x)) so find_rewrites discovers:
+        // Eq(Abs x, 0) ↔ Eq(x, 0) and Ge(0, Abs x) ↔ Eq(x, 0) (all true only at x=0).
+        // This unifies those e-classes so the four Ge-weakening Abs rules collapse to
+        // the two canonical Gt(Abs x, 0) rules.
+        let abs_preds = Workload::new(&["(SIGN (Abs x) 0)", "(SIGN 0 (Abs x))"])
+            .plug("SIGN", &sign_ops);
+        let sym_wkld = sym_atom_preds.append(sym_and_preds).append(neg_preds).append(abs_preds);
 
         let (sym_rewrites, _) = bubbler.find_rewrites(&sym_wkld, &Workload::empty());
         let InferredFacts::Rewrites(sym_rewrites) = sym_rewrites else {
@@ -488,6 +501,27 @@ mod tests {
             println!("  {}", rw);
         }
         for rw in &sym_rewrites {
+            bubbler.register_rewrite(rw).unwrap();
+        }
+
+        // === Step 1.5: Learn Add/Mul rewrite rules ===
+        // Discovers commutativity (Add a b ~> Add b a, Mul a b ~> Mul b a) so
+        // that the implication phases treat e.g. Mul(a,b) and Mul(b,a) as
+        // equivalent, collapsing duplicate implications.
+        let add_mul_wkld = Workload::new(["(OP VAR VAR)"])
+            .plug("OP", &Workload::new(&["Add", "Mul"]))
+            .plug("VAR", &Workload::new(&["x", "y"]));
+
+        let (add_mul_rws, _) = bubbler.find_rewrites(&add_mul_wkld, &Workload::empty());
+        let InferredFacts::Rewrites(add_mul_rws) = add_mul_rws else {
+            panic!("Expected rewrites")
+        };
+
+        println!("=== Add/Mul rewrites ({}) ===", add_mul_rws.len());
+        for rw in &add_mul_rws {
+            println!("  {}", rw);
+        }
+        for rw in &add_mul_rws {
             bubbler.register_rewrite(rw).unwrap();
         }
 
@@ -510,46 +544,80 @@ mod tests {
             bubbler.register_implication(imp).unwrap();
         }
 
-        // === Step 3: Conjunctive implication discovery ===
-        // Now with symmetries and lattice known, enumerate single predicates over
-        // compound terms plus cross-variable And predicates.
-        let compound_terms =
-            Workload::new(&["x", "y", "(Add x y)", "(Mul x y)", "(Neg x)", "(Abs x)"]);
-        let single_preds = Workload::new(&["(SIGN TERM 0)"])
-            .plug("SIGN", &sign_ops)
-            .plug("TERM", &compound_terms);
+        // === Step 3: Piecemeal conjunctive discovery — Add then Mul ===
+        // Running Add and Mul together bloats the candidate set. Separate passes
+        // keep each workload small and let us inspect results per-operator.
+
         let and_preds = Workload::new(&["(And P Q)"])
             .plug("P", &x_preds)
             .plug("Q", &y_preds);
-
-        // Within-variable Or, distinct-predicate pairs only (no Or(P,P)).
-        // Or(Gt,Ge), Or(Lt,Le), Or(Ge,Le) etc. collapse to the broader predicate
-        // or a tautology; the PVec-lattice filter in PvecMatch prunes those.
-        // Or(Gt,Lt) = nonzero is the genuinely new case-split predicate.
         let x_or_preds = Workload::new(&[
-            "(Or (Gt x 0) (Lt x 0))", "(Or (Gt x 0) (Ge x 0))", "(Or (Gt x 0) (Le x 0))",
-            "(Or (Gt x 0) (Eq x 0))", "(Or (Lt x 0) (Ge x 0))", "(Or (Lt x 0) (Le x 0))",
-            "(Or (Lt x 0) (Eq x 0))", "(Or (Ge x 0) (Le x 0))", "(Or (Ge x 0) (Eq x 0))",
+            "(Or (Gt x 0) (Lt x 0))",
+            "(Or (Gt x 0) (Ge x 0))",
+            "(Or (Gt x 0) (Le x 0))",
+            "(Or (Gt x 0) (Eq x 0))",
+            "(Or (Lt x 0) (Ge x 0))",
+            "(Or (Lt x 0) (Le x 0))",
+            "(Or (Lt x 0) (Eq x 0))",
+            "(Or (Ge x 0) (Le x 0))",
+            "(Or (Ge x 0) (Eq x 0))",
             "(Or (Le x 0) (Eq x 0))",
         ]);
         let y_or_preds = Workload::new(&[
-            "(Or (Gt y 0) (Lt y 0))", "(Or (Gt y 0) (Ge y 0))", "(Or (Gt y 0) (Le y 0))",
-            "(Or (Gt y 0) (Eq y 0))", "(Or (Lt y 0) (Ge y 0))", "(Or (Lt y 0) (Le y 0))",
-            "(Or (Lt y 0) (Eq y 0))", "(Or (Ge y 0) (Le y 0))", "(Or (Ge y 0) (Eq y 0))",
+            "(Or (Gt y 0) (Lt y 0))",
+            "(Or (Gt y 0) (Ge y 0))",
+            "(Or (Gt y 0) (Le y 0))",
+            "(Or (Gt y 0) (Eq y 0))",
+            "(Or (Lt y 0) (Ge y 0))",
+            "(Or (Lt y 0) (Le y 0))",
+            "(Or (Lt y 0) (Eq y 0))",
+            "(Or (Ge y 0) (Le y 0))",
+            "(Or (Ge y 0) (Eq y 0))",
             "(Or (Le y 0) (Eq y 0))",
         ]);
 
-        let pred_wkld = single_preds.append(and_preds).append(x_or_preds).append(y_or_preds);
+        // --- 3a: Add ---
+        let add_terms = Workload::new(&["x", "y", "(Add x y)", "(Neg x)", "(Abs x)"]);
+        let add_single = Workload::new(&["(SIGN TERM 0)"])
+            .plug("SIGN", &sign_ops)
+            .plug("TERM", &add_terms);
+        let add_wkld = add_single
+            .append(and_preds.clone())
+            .append(x_or_preds.clone())
+            .append(y_or_preds.clone());
 
-        let result = bubbler.find_implications(&pred_wkld);
-        let InferredFacts::Implications(implications) = result else {
-            panic!("Expected implications")
+        let add_result = bubbler.find_implications(&add_wkld);
+        let InferredFacts::Implications(add_imps) = add_result else {
+            panic!()
         };
-
-        println!("=== Conjunctive implications ({}) ===", implications.len());
-        for imp in &implications {
+        println!("=== Add implications ({}) ===", add_imps.len());
+        for imp in &add_imps {
             println!("  {}", imp);
         }
+        for imp in &add_imps {
+            bubbler.register_implication(imp).unwrap();
+        }
+
+        // --- 3b: Mul ---
+        let mul_terms = Workload::new(&["x", "y", "(Mul x y)", "(Neg x)", "(Abs x)"]);
+        let mul_single = Workload::new(&["(SIGN TERM 0)"])
+            .plug("SIGN", &sign_ops)
+            .plug("TERM", &mul_terms);
+        let mul_wkld = mul_single
+            .append(and_preds)
+            .append(x_or_preds)
+            .append(y_or_preds);
+
+        let mul_result = bubbler.find_implications(&mul_wkld);
+        let InferredFacts::Implications(mul_imps) = mul_result else {
+            panic!()
+        };
+        println!("=== Mul implications ({}) ===", mul_imps.len());
+        for imp in &mul_imps {
+            println!("  {}", imp);
+        }
+
+        let implications: Vec<_> = add_imps.iter().chain(mul_imps.iter()).cloned().collect();
 
         // Helper: check a single-antecedent implication by outer operator.
         let has_impl = |from_op: &LLVMLangOp, to_op: &LLVMLangOp| {
@@ -592,22 +660,39 @@ mod tests {
             })
         };
 
-        let dump = || implications.iter().map(|i| i.to_string()).collect::<Vec<_>>();
+        let dump = || {
+            implications
+                .iter()
+                .map(|i| i.to_string())
+                .collect::<Vec<_>>()
+        };
 
         // Lattice ordering: these are in lattice_imps (registered as context),
         // NOT in the conjunctive phase output. Check lattice_imps directly.
         // neg→nonpos appears as (Lt ?a 0) → (Ge 0 ?a) due to Le↔Ge symmetry.
         let has_lattice_impl = |from_op: &LLVMLangOp, to_op: &LLVMLangOp| {
             lattice_imps.iter().any(|imp| {
-                let Condition::Predicate(fp) = &imp.from else { return false };
-                let Term::Call(f, _) = &fp.term else { return false };
-                let Term::Call(t, _) = &imp.to.term else { return false };
+                let Condition::Predicate(fp) = &imp.from else {
+                    return false;
+                };
+                let Term::Call(f, _) = &fp.term else {
+                    return false;
+                };
+                let Term::Call(t, _) = &imp.to.term else {
+                    return false;
+                };
                 f == from_op && t == to_op
             })
         };
-        assert!(has_lattice_impl(&LLVMLangOp::Gt, &LLVMLangOp::Ge), "pos → nonneg");
+        assert!(
+            has_lattice_impl(&LLVMLangOp::Gt, &LLVMLangOp::Ge),
+            "pos → nonneg"
+        );
         // neg → nonpos appears as (Lt ?a 0) → (Ge 0 ?a) via Le↔Ge symmetry rewrite.
-        assert!(has_lattice_impl(&LLVMLangOp::Lt, &LLVMLangOp::Ge), "neg → nonpos (as Ge(0,x))");
+        assert!(
+            has_lattice_impl(&LLVMLangOp::Lt, &LLVMLangOp::Ge),
+            "neg → nonpos (as Ge(0,x))"
+        );
 
         // Mul sign case-splits via Or: Gt(Mul(a,b), 0) → Or(nonzero(a/b)).
         // The antecedent outer op is Gt or Lt; Mul is nested as the first argument.
@@ -616,14 +701,23 @@ mod tests {
         // may not be generated. Next thing to investigate.
         assert!(
             implications.iter().any(|imp| {
-                let Condition::Predicate(fp) = &imp.from else { return false };
-                let Term::Call(sign, args) = &fp.term else { return false };
-                if !matches!(sign, LLVMLangOp::Gt | LLVMLangOp::Lt) { return false }
-                if args.is_empty() { return false }
+                let Condition::Predicate(fp) = &imp.from else {
+                    return false;
+                };
+                let Term::Call(sign, args) = &fp.term else {
+                    return false;
+                };
+                if !matches!(sign, LLVMLangOp::Gt | LLVMLangOp::Lt) {
+                    return false;
+                }
+                if args.is_empty() {
+                    return false;
+                }
                 let is_mul_arg = matches!(&args[0], Term::Call(LLVMLangOp::Mul, _));
                 is_mul_arg && matches!(&imp.to.term, Term::Call(LLVMLangOp::Or, _))
             }),
-            "Expected Mul-sign → Or(nonzero) rule; got: {:?}", dump()
+            "Expected Mul-sign → Or(nonzero) rule; got: {:?}",
+            dump()
         );
     }
 

--- a/src/test_langs/llvm.rs
+++ b/src/test_langs/llvm.rs
@@ -23,6 +23,9 @@ pub enum LLVMLangOp {
     Min,
     Max,
     Neq,
+    Eq,
+    Neg,
+    Abs,
 }
 
 impl OpTrait for LLVMLangOp {
@@ -40,6 +43,9 @@ impl OpTrait for LLVMLangOp {
             LLVMLangOp::Min => 2,
             LLVMLangOp::Max => 2,
             LLVMLangOp::Neq => 2,
+            LLVMLangOp::Eq => 2,
+            LLVMLangOp::Neg => 1,
+            LLVMLangOp::Abs => 1,
         }
     }
 
@@ -57,6 +63,9 @@ impl OpTrait for LLVMLangOp {
             LLVMLangOp::Min => "Min",
             LLVMLangOp::Max => "Max",
             LLVMLangOp::Neq => "Neq",
+            LLVMLangOp::Eq => "Eq",
+            LLVMLangOp::Neg => "Neg",
+            LLVMLangOp::Abs => "Abs",
         }
     }
 }
@@ -84,6 +93,9 @@ impl FromStr for LLVMLangOp {
             "Min" => Ok(LLVMLangOp::Min),
             "Max" => Ok(LLVMLangOp::Max),
             "Neq" => Ok(LLVMLangOp::Neq),
+            "Eq" => Ok(LLVMLangOp::Eq),
+            "Neg" => Ok(LLVMLangOp::Neg),
+            "Abs" => Ok(LLVMLangOp::Abs),
             _ => Err(format!("Unknown LLVMLangOp: {}", s)),
         }
     }
@@ -126,6 +138,9 @@ impl Language for LLVMLang {
             LLVMLangOp::Min,
             LLVMLangOp::Max,
             LLVMLangOp::Neq,
+            LLVMLangOp::Eq,
+            LLVMLangOp::Neg,
+            LLVMLangOp::Abs,
         ]
     }
 
@@ -279,6 +294,26 @@ impl Language for LLVMLang {
                     })
                     .collect()
             }
+            LLVMLangOp::Eq => {
+                let left_vec = &child_vecs[0];
+                let right_vec = &child_vecs[1];
+                left_vec
+                    .iter()
+                    .zip(right_vec.iter())
+                    .map(|(l, r)| match (l, r) {
+                        (Some(lv), Some(rv)) => Some((lv == rv) as i64),
+                        _ => None,
+                    })
+                    .collect()
+            }
+            LLVMLangOp::Neg => {
+                let child_vec = &child_vecs[0];
+                child_vec.iter().map(|v| v.map(|cv| -cv)).collect()
+            }
+            LLVMLangOp::Abs => {
+                let child_vec = &child_vecs[0];
+                child_vec.iter().map(|v| v.map(|cv| cv.abs())).collect()
+            }
         }
     }
 }
@@ -287,8 +322,158 @@ impl Language for LLVMLang {
 #[allow(unused_imports)]
 mod tests {
     use super::*;
-    use crate::bubbler::{Bubbler, BubblerConfig, InferredFacts};
+    use crate::bubbler::{Bubbler, BubblerConfig, Condition, InferredFacts};
+    use crate::language::term::Term;
     use ruler::enumo::Workload;
+
+    // --- Phase 2: Axiom discovery ---
+
+    /// Discriminating test: checks both that genuine axioms are found AND
+    /// that contingent predicates are excluded.
+    #[test]
+    fn find_sign_axioms() {
+        let bubbler: Bubbler<LLVMLang> =
+            Bubbler::new(BubblerConfig::new(vec!["x".into()], vec![]));
+
+        // Mix of axioms and non-axioms. interesting_constants includes -10, -1, 0, 1, 2, ...
+        // so all slots are exercised.
+        let wkld = Workload::new(&[
+            "(Ge (Abs x) 0)",   // axiom: abs always >= 0
+            "(Ge (Mul x x) 0)", // axiom: square always >= 0
+            "(Ge x 0)",         // NOT axiom: false at x = -1
+            "(Gt (Abs x) 0)",   // NOT axiom: false at x = 0
+        ]);
+
+        let result = bubbler.find_axioms(&wkld);
+        let InferredFacts::Axioms(axioms) = result else {
+            panic!("Expected axioms");
+        };
+
+        // to_sexp() produces "(Ge (Abs (Var x ) ) (Const 0 ) )" — match structurally.
+        let matches = |axioms: &[_], op: &str, inner: &str| -> bool {
+            axioms.iter().any(|p: &crate::language::PredicateTerm<LLVMLang>| {
+                let s = p.term.to_sexp().to_string();
+                s.contains(op) && s.contains(inner)
+            })
+        };
+
+        assert!(
+            matches(&axioms, "Ge", "Abs"),
+            "expected (Ge (Abs x) 0) as axiom; got: {:?}",
+            axioms.iter().map(|p| p.term.to_sexp().to_string()).collect::<Vec<_>>()
+        );
+        assert!(
+            matches(&axioms, "Ge", "Mul"),
+            "expected (Ge (Mul x x) 0) as axiom; got: {:?}",
+            axioms.iter().map(|p| p.term.to_sexp().to_string()).collect::<Vec<_>>()
+        );
+
+        // Contingent predicates must not appear.
+        let contingent_present = axioms.iter().any(|p| {
+            let s = p.term.to_sexp().to_string();
+            // (Ge x 0) — no Abs or Mul, just a bare Var
+            (s.contains("Ge") && !s.contains("Abs") && !s.contains("Mul"))
+                // (Gt (Abs x) 0)
+                || (s.contains("Gt") && s.contains("Abs"))
+        });
+        assert!(
+            !contingent_present,
+            "contingent predicate found in axioms: {:?}",
+            axioms.iter().map(|p| p.term.to_sexp().to_string()).collect::<Vec<_>>()
+        );
+    }
+
+    // --- Phase 3: Signedness propagation (gating experiment) ---
+    //
+    // Ground truth for recall measurement:
+    //   pos(x) ∧ pos(y) → pos(x+y)          [needs conjunction]
+    //   neg(x) ∧ neg(y) → neg(x+y)          [needs conjunction]
+    //   nonneg(x) ∧ nonneg(y) → nonneg(x+y) [needs conjunction]
+    //   zero(x) → zero(x*y)                  [single-predicate — discoverable]
+    //   pos(x) ∧ pos(y) → pos(x*y)           [needs conjunction]
+    //   neg(x) ∧ neg(y) → pos(x*y)           [needs conjunction]
+    //   pos(x) → neg(-x)                     [single-predicate — discoverable]
+    //   neg(x) → pos(-x)                     [single-predicate — discoverable]
+    //   zero(x) → zero(-x)                   [single-predicate — discoverable]
+    //   nonneg(abs(x))                        [axiom — Phase 2]
+    //
+    // The current PvecMatch only surfaces single-predicate antecedent rules.
+    // Conjunctive rules require an extended matcher. This test measures what
+    // the existing loop actually finds and is intended to document the gap.
+
+    // NOTE: two-variable predicate workloads (e.g. (Gt (Add x y) 0)) produce
+    // implication candidates where the consequent contains a variable (`y`) that
+    // does not appear in the antecedent. Egglog rejects these with an "Unbound"
+    // error. Multi-variable discovery requires extending the implication model to
+    // support conjunctive antecedents; this test documents what is discoverable
+    // today with single-variable predicates only.
+    #[test]
+    fn discover_sign_implications() {
+        let mut bubbler: Bubbler<LLVMLang> =
+            Bubbler::new(BubblerConfig::new(vec!["x".into()], vec![]));
+
+        // Single-variable predicate workload: sign predicates over x and unary terms.
+        // pos(x) := (Gt x 0), neg(x) := (Lt x 0), nonneg(x) := (Ge x 0),
+        // nonpos(x) := (Le x 0), zero(x) := (Eq x 0)
+        let depth1_terms = Workload::new(&["x", "(Neg x)", "(Abs x)", "(Mul x x)"]);
+
+        let pred_wkld = Workload::new(&["(SIGN TERM 0)"])
+            .plug("SIGN", &Workload::new(&["Gt", "Lt", "Ge", "Le", "Eq"]))
+            .plug("TERM", &depth1_terms);
+
+        // Phase 1: find rewrites over the predicate language to reduce redundancy.
+        let (pred_rewrites, _) = bubbler.find_rewrites(&pred_wkld, &Workload::empty());
+        let InferredFacts::Rewrites(pred_rewrites) = pred_rewrites else {
+            panic!("Expected rewrites");
+        };
+        for rw in &pred_rewrites {
+            bubbler.register_rewrite(rw).unwrap();
+        }
+
+        // Phase 2: find implications.
+        let result = bubbler.find_implications(&pred_wkld);
+        let InferredFacts::Implications(implications) = result else {
+            panic!("Expected implications");
+        };
+
+        println!("=== Discovered sign implications ({}) ===", implications.len());
+        for imp in &implications {
+            println!("  {}", imp);
+        }
+
+        // Rules 3–5 (pos↔neg(-x), neg↔pos(-x), zero↔zero(-x)) have identical
+        // PVecs, so they are found as rewrites in phase 1 — not implications here.
+        // The strictly one-way lattice-ordering implications are:
+        //   pos(x)  → nonneg(x)   from: Gt, to: Ge
+        //   neg(x)  → nonpos(x)   from: Lt, to: Le
+        let has_implication = |from_op: &LLVMLangOp, to_op: &LLVMLangOp| {
+            implications.iter().any(|imp| {
+                let Condition::Predicate(from_pred) = &imp.from else {
+                    return false;
+                };
+                let Term::Call(f, _) = &from_pred.term else {
+                    return false;
+                };
+                let Term::Call(t, _) = &imp.to.term else {
+                    return false;
+                };
+                f == from_op && t == to_op
+            })
+        };
+
+        assert!(
+            has_implication(&LLVMLangOp::Gt, &LLVMLangOp::Ge),
+            "Expected pos(x) → nonneg(x); got: {:?}",
+            implications.iter().map(|i| i.to_string()).collect::<Vec<_>>()
+        );
+        assert!(
+            has_implication(&LLVMLangOp::Lt, &LLVMLangOp::Le),
+            "Expected neg(x) → nonpos(x); got: {:?}",
+            implications.iter().map(|i| i.to_string()).collect::<Vec<_>>()
+        );
+    }
+
+    // --- Original implication tests ---
 
     #[test]
     fn find_implications_poor_schedule() {

--- a/src/test_langs/llvm.rs
+++ b/src/test_langs/llvm.rs
@@ -12,6 +12,7 @@ pub struct LLVMLang;
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum LLVMLangOp {
     And,
+    Or,
     Add,
     Sub,
     Mul,
@@ -32,6 +33,7 @@ impl OpTrait for LLVMLangOp {
     fn arity(&self) -> usize {
         match self {
             LLVMLangOp::And => 2,
+            LLVMLangOp::Or => 2,
             LLVMLangOp::Add => 2,
             LLVMLangOp::Sub => 2,
             LLVMLangOp::Mul => 2,
@@ -52,6 +54,7 @@ impl OpTrait for LLVMLangOp {
     fn name(&self) -> &'static str {
         match self {
             LLVMLangOp::And => "And",
+            LLVMLangOp::Or => "Or",
             LLVMLangOp::Add => "Add",
             LLVMLangOp::Sub => "Sub",
             LLVMLangOp::Mul => "Mul",
@@ -68,6 +71,9 @@ impl OpTrait for LLVMLangOp {
             LLVMLangOp::Abs => "Abs",
         }
     }
+
+    fn is_conjunction(&self) -> bool { matches!(self, LLVMLangOp::And) }
+    fn is_disjunction(&self) -> bool { matches!(self, LLVMLangOp::Or) }
 }
 
 impl Display for LLVMLangOp {
@@ -82,6 +88,7 @@ impl FromStr for LLVMLangOp {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "And" => Ok(LLVMLangOp::And),
+            "Or" => Ok(LLVMLangOp::Or),
             "Add" => Ok(LLVMLangOp::Add),
             "Sub" => Ok(LLVMLangOp::Sub),
             "Mul" => Ok(LLVMLangOp::Mul),
@@ -127,6 +134,7 @@ impl Language for LLVMLang {
     fn ops() -> Vec<Self::Op> {
         vec![
             LLVMLangOp::And,
+            LLVMLangOp::Or,
             LLVMLangOp::Add,
             LLVMLangOp::Sub,
             LLVMLangOp::Mul,
@@ -157,6 +165,18 @@ impl Language for LLVMLang {
                     .zip(right_vec.iter())
                     .map(|(l, r)| match (l, r) {
                         (Some(lv), Some(rv)) => Some(((*lv != 0) && (*rv != 0)) as i64),
+                        _ => None,
+                    })
+                    .collect()
+            }
+            LLVMLangOp::Or => {
+                let left_vec = &child_vecs[0];
+                let right_vec = &child_vecs[1];
+                left_vec
+                    .iter()
+                    .zip(right_vec.iter())
+                    .map(|(l, r)| match (l, r) {
+                        (Some(lv), Some(rv)) => Some(((*lv != 0) || (*rv != 0)) as i64),
                         _ => None,
                     })
                     .collect()
@@ -332,8 +352,7 @@ mod tests {
     /// that contingent predicates are excluded.
     #[test]
     fn find_sign_axioms() {
-        let bubbler: Bubbler<LLVMLang> =
-            Bubbler::new(BubblerConfig::new(vec!["x".into()], vec![]));
+        let bubbler: Bubbler<LLVMLang> = Bubbler::new(BubblerConfig::new(vec!["x".into()], vec![]));
 
         // Mix of axioms and non-axioms. interesting_constants includes -10, -1, 0, 1, 2, ...
         // so all slots are exercised.
@@ -351,21 +370,29 @@ mod tests {
 
         // to_sexp() produces "(Ge (Abs (Var x ) ) (Const 0 ) )" — match structurally.
         let matches = |axioms: &[_], op: &str, inner: &str| -> bool {
-            axioms.iter().any(|p: &crate::language::PredicateTerm<LLVMLang>| {
-                let s = p.term.to_sexp().to_string();
-                s.contains(op) && s.contains(inner)
-            })
+            axioms
+                .iter()
+                .any(|p: &crate::language::PredicateTerm<LLVMLang>| {
+                    let s = p.term.to_sexp().to_string();
+                    s.contains(op) && s.contains(inner)
+                })
         };
 
         assert!(
             matches(&axioms, "Ge", "Abs"),
             "expected (Ge (Abs x) 0) as axiom; got: {:?}",
-            axioms.iter().map(|p| p.term.to_sexp().to_string()).collect::<Vec<_>>()
+            axioms
+                .iter()
+                .map(|p| p.term.to_sexp().to_string())
+                .collect::<Vec<_>>()
         );
         assert!(
             matches(&axioms, "Ge", "Mul"),
             "expected (Ge (Mul x x) 0) as axiom; got: {:?}",
-            axioms.iter().map(|p| p.term.to_sexp().to_string()).collect::<Vec<_>>()
+            axioms
+                .iter()
+                .map(|p| p.term.to_sexp().to_string())
+                .collect::<Vec<_>>()
         );
 
         // Contingent predicates must not appear.
@@ -379,7 +406,10 @@ mod tests {
         assert!(
             !contingent_present,
             "contingent predicate found in axioms: {:?}",
-            axioms.iter().map(|p| p.term.to_sexp().to_string()).collect::<Vec<_>>()
+            axioms
+                .iter()
+                .map(|p| p.term.to_sexp().to_string())
+                .collect::<Vec<_>>()
         );
     }
 
@@ -401,57 +431,133 @@ mod tests {
     // Conjunctive rules require an extended matcher. This test measures what
     // the existing loop actually finds and is intended to document the gap.
 
-    // NOTE: two-variable predicate workloads (e.g. (Gt (Add x y) 0)) produce
-    // implication candidates where the consequent contains a variable (`y`) that
-    // does not appear in the antecedent. Egglog rejects these with an "Unbound"
-    // error. Multi-variable discovery requires extending the implication model to
-    // support conjunctive antecedents; this test documents what is discoverable
-    // today with single-variable predicates only.
+    // Schedule:
+    //   Step 1 — synthesize predicate symmetry rewrites (Gt(x,0)≡Lt(0,x), And
+    //            commutativity, etc.) so the e-graph collapses redundant forms.
+    //   Step 2 — synthesize the predicate-strength lattice (pos→nonneg etc.)
+    //            using the compressed representation.
+    //   Step 3 — discover conjunctive implications over the narrowed And workload.
     #[test]
     fn discover_sign_implications() {
         let mut bubbler: Bubbler<LLVMLang> =
-            Bubbler::new(BubblerConfig::new(vec!["x".into()], vec![]));
+            Bubbler::new(BubblerConfig::new(vec!["x".into(), "y".into()], vec![]));
 
-        // Single-variable predicate workload: sign predicates over x and unary terms.
-        // pos(x) := (Gt x 0), neg(x) := (Lt x 0), nonneg(x) := (Ge x 0),
-        // nonpos(x) := (Le x 0), zero(x) := (Eq x 0)
-        let depth1_terms = Workload::new(&["x", "(Neg x)", "(Abs x)", "(Mul x x)"]);
+        let sign_ops = Workload::new(&["Gt", "Lt", "Ge", "Le", "Eq"]);
 
-        let pred_wkld = Workload::new(&["(SIGN TERM 0)"])
-            .plug("SIGN", &Workload::new(&["Gt", "Lt", "Ge", "Le", "Eq"]))
-            .plug("TERM", &depth1_terms);
+        // === Step 0: Find rewrites over the term language to simplify the CVec space before finding
+        // implications.
 
-        // Phase 1: find rewrites over the predicate language to reduce redundancy.
-        let (pred_rewrites, _) = bubbler.find_rewrites(&pred_wkld, &Workload::empty());
-        let InferredFacts::Rewrites(pred_rewrites) = pred_rewrites else {
-            panic!("Expected rewrites");
+        let vars = Workload::new(&["x", "y"]);
+        let terms = Workload::new(&["(OP VAR VAR)"])
+            .plug("OP", &Workload::new(&["And", "Gt", "Lt", "Ge", "Le", "Eq"]))
+            .plug("VAR", &vars);
+
+        let (rws, _) = bubbler.find_rewrites(&terms, &Workload::empty());
+        let InferredFacts::Rewrites(rws) = rws else {
+            panic!("Expected rewrites")
         };
-        for rw in &pred_rewrites {
+        for rw in &rws {
+            println!("=== Pre-implication rewrite: {}", rw);
             bubbler.register_rewrite(rw).unwrap();
         }
 
-        // Phase 2: find implications.
+        // === Step 1: Predicate symmetry rewrites ===
+        // Include both (SIGN VAR 0) and (SIGN 0 VAR) so find_rewrites sees that
+        // e.g. Gt(x,0) and Lt(0,x) have the same CVec → discovered as equivalent.
+        // Also include cross-variable And predicates to find commutativity.
+        let x_preds = Workload::new(&["(SIGN x 0)"]).plug("SIGN", &sign_ops);
+        let y_preds = Workload::new(&["(SIGN y 0)"]).plug("SIGN", &sign_ops);
+
+        // Signedness only: (SIGN x 0) and (SIGN 0 x) to discover the constant-flip
+        // rewrites (Gt(x,0) ↔ Lt(0,x) etc.). General order rewrites (Gt ?a ?b) ↔
+        // (Lt ?b ?a) are a separate phase outside signedness analysis.
+        let sym_atom_preds = Workload::new(&["(SIGN VAR 0)", "(SIGN 0 VAR)"])
+            .plug("SIGN", &sign_ops)
+            .plug("VAR", &Workload::new(&["x", "y"]));
+        let sym_and_preds = Workload::new(&["(And P Q)"])
+            .plug("P", &x_preds)
+            .plug("Q", &y_preds);
+        let sym_wkld = sym_atom_preds.append(sym_and_preds);
+
+        let (sym_rewrites, _) = bubbler.find_rewrites(&sym_wkld, &Workload::empty());
+        let InferredFacts::Rewrites(sym_rewrites) = sym_rewrites else {
+            panic!("Expected rewrites")
+        };
+        println!("=== Symmetry rewrites ({}) ===", sym_rewrites.len());
+        for rw in &sym_rewrites {
+            println!("  {}", rw);
+        }
+        for rw in &sym_rewrites {
+            bubbler.register_rewrite(rw).unwrap();
+        }
+
+        // === Step 2: Predicate-strength lattice (Phase 0) ===
+        // Run find_implications over single-variable predicates only; the symmetry
+        // rewrites above compress the PVec space before this runs.
+        let lattice_wkld = Workload::new(&["(SIGN VAR 0)"])
+            .plug("SIGN", &sign_ops)
+            .plug("VAR", &Workload::new(&["x", "y"]));
+
+        let lattice_imps = bubbler.find_implications(&lattice_wkld);
+        let InferredFacts::Implications(lattice_imps) = lattice_imps else {
+            panic!("Expected implications")
+        };
+        println!("=== Lattice implications ({}) ===", lattice_imps.len());
+        for imp in &lattice_imps {
+            println!("  {}", imp);
+        }
+        for imp in &lattice_imps {
+            bubbler.register_implication(imp).unwrap();
+        }
+
+        // === Step 3: Conjunctive implication discovery ===
+        // Now with symmetries and lattice known, enumerate single predicates over
+        // compound terms plus cross-variable And predicates.
+        let compound_terms =
+            Workload::new(&["x", "y", "(Add x y)", "(Mul x y)", "(Neg x)", "(Abs x)"]);
+        let single_preds = Workload::new(&["(SIGN TERM 0)"])
+            .plug("SIGN", &sign_ops)
+            .plug("TERM", &compound_terms);
+        let and_preds = Workload::new(&["(And P Q)"])
+            .plug("P", &x_preds)
+            .plug("Q", &y_preds);
+
+        // Within-variable Or, distinct-predicate pairs only (no Or(P,P)).
+        // Or(Gt,Ge), Or(Lt,Le), Or(Ge,Le) etc. collapse to the broader predicate
+        // or a tautology; the PVec-lattice filter in PvecMatch prunes those.
+        // Or(Gt,Lt) = nonzero is the genuinely new case-split predicate.
+        let x_or_preds = Workload::new(&[
+            "(Or (Gt x 0) (Lt x 0))", "(Or (Gt x 0) (Ge x 0))", "(Or (Gt x 0) (Le x 0))",
+            "(Or (Gt x 0) (Eq x 0))", "(Or (Lt x 0) (Ge x 0))", "(Or (Lt x 0) (Le x 0))",
+            "(Or (Lt x 0) (Eq x 0))", "(Or (Ge x 0) (Le x 0))", "(Or (Ge x 0) (Eq x 0))",
+            "(Or (Le x 0) (Eq x 0))",
+        ]);
+        let y_or_preds = Workload::new(&[
+            "(Or (Gt y 0) (Lt y 0))", "(Or (Gt y 0) (Ge y 0))", "(Or (Gt y 0) (Le y 0))",
+            "(Or (Gt y 0) (Eq y 0))", "(Or (Lt y 0) (Ge y 0))", "(Or (Lt y 0) (Le y 0))",
+            "(Or (Lt y 0) (Eq y 0))", "(Or (Ge y 0) (Le y 0))", "(Or (Ge y 0) (Eq y 0))",
+            "(Or (Le y 0) (Eq y 0))",
+        ]);
+
+        let pred_wkld = single_preds.append(and_preds).append(x_or_preds).append(y_or_preds);
+
         let result = bubbler.find_implications(&pred_wkld);
         let InferredFacts::Implications(implications) = result else {
-            panic!("Expected implications");
+            panic!("Expected implications")
         };
 
-        println!("=== Discovered sign implications ({}) ===", implications.len());
+        println!("=== Conjunctive implications ({}) ===", implications.len());
         for imp in &implications {
             println!("  {}", imp);
         }
 
-        // Rules 3–5 (pos↔neg(-x), neg↔pos(-x), zero↔zero(-x)) have identical
-        // PVecs, so they are found as rewrites in phase 1 — not implications here.
-        // The strictly one-way lattice-ordering implications are:
-        //   pos(x)  → nonneg(x)   from: Gt, to: Ge
-        //   neg(x)  → nonpos(x)   from: Lt, to: Le
-        let has_implication = |from_op: &LLVMLangOp, to_op: &LLVMLangOp| {
+        // Helper: check a single-antecedent implication by outer operator.
+        let has_impl = |from_op: &LLVMLangOp, to_op: &LLVMLangOp| {
             implications.iter().any(|imp| {
-                let Condition::Predicate(from_pred) = &imp.from else {
+                let Condition::Predicate(fp) = &imp.from else {
                     return false;
                 };
-                let Term::Call(f, _) = &from_pred.term else {
+                let Term::Call(f, _) = &fp.term else {
                     return false;
                 };
                 let Term::Call(t, _) = &imp.to.term else {
@@ -461,15 +567,128 @@ mod tests {
             })
         };
 
+        // Helper: check a conjunctive And(sign1, sign2) → sign3 implication.
+        let has_conj_impl = |p_op: &LLVMLangOp, q_op: &LLVMLangOp, to_op: &LLVMLangOp| {
+            implications.iter().any(|imp| {
+                let Condition::Predicate(fp) = &imp.from else {
+                    return false;
+                };
+                let Term::Call(LLVMLangOp::And, args) = &fp.term else {
+                    return false;
+                };
+                if args.len() != 2 {
+                    return false;
+                }
+                let Term::Call(p, _) = &args[0] else {
+                    return false;
+                };
+                let Term::Call(q, _) = &args[1] else {
+                    return false;
+                };
+                let Term::Call(t, _) = &imp.to.term else {
+                    return false;
+                };
+                p == p_op && q == q_op && t == to_op
+            })
+        };
+
+        let dump = || implications.iter().map(|i| i.to_string()).collect::<Vec<_>>();
+
+        // Lattice ordering: these are in lattice_imps (registered as context),
+        // NOT in the conjunctive phase output. Check lattice_imps directly.
+        // neg→nonpos appears as (Lt ?a 0) → (Ge 0 ?a) due to Le↔Ge symmetry.
+        let has_lattice_impl = |from_op: &LLVMLangOp, to_op: &LLVMLangOp| {
+            lattice_imps.iter().any(|imp| {
+                let Condition::Predicate(fp) = &imp.from else { return false };
+                let Term::Call(f, _) = &fp.term else { return false };
+                let Term::Call(t, _) = &imp.to.term else { return false };
+                f == from_op && t == to_op
+            })
+        };
+        assert!(has_lattice_impl(&LLVMLangOp::Gt, &LLVMLangOp::Ge), "pos → nonneg");
+        // neg → nonpos appears as (Lt ?a 0) → (Ge 0 ?a) via Le↔Ge symmetry rewrite.
+        assert!(has_lattice_impl(&LLVMLangOp::Lt, &LLVMLangOp::Ge), "neg → nonpos (as Ge(0,x))");
+
+        // Mul sign case-splits via Or: Gt(Mul(a,b), 0) → Or(nonzero(a/b)).
+        // The antecedent outer op is Gt or Lt; Mul is nested as the first argument.
+        // NOTE: pos(a)∧pos(b)→pos(a+b) is not yet discovered — likely a workload gap.
+        // Add(x,y) is in compound_terms but PVec for And(pos(x),pos(y))→pos(Add(x,y))
+        // may not be generated. Next thing to investigate.
         assert!(
-            has_implication(&LLVMLangOp::Gt, &LLVMLangOp::Ge),
-            "Expected pos(x) → nonneg(x); got: {:?}",
-            implications.iter().map(|i| i.to_string()).collect::<Vec<_>>()
+            implications.iter().any(|imp| {
+                let Condition::Predicate(fp) = &imp.from else { return false };
+                let Term::Call(sign, args) = &fp.term else { return false };
+                if !matches!(sign, LLVMLangOp::Gt | LLVMLangOp::Lt) { return false }
+                if args.is_empty() { return false }
+                let is_mul_arg = matches!(&args[0], Term::Call(LLVMLangOp::Mul, _));
+                is_mul_arg && matches!(&imp.to.term, Term::Call(LLVMLangOp::Or, _))
+            }),
+            "Expected Mul-sign → Or(nonzero) rule; got: {:?}", dump()
+        );
+    }
+
+    // Phase C: conditional rewrites via find_rewrites.
+    // Expected: nonneg(x) → abs(x) ≡ x  and  nonpos(x) → abs(x) ≡ -x
+    #[test]
+    fn discover_sign_conditional_rewrites() {
+        let mut bubbler: Bubbler<LLVMLang> =
+            Bubbler::new(BubblerConfig::new(vec!["x".into()], vec![]));
+
+        let term_wkld = Workload::new(&["x", "(Abs x)", "(Neg x)"]);
+        let sign_preds = Workload::new(&["(Ge x 0)", "(Gt x 0)", "(Le x 0)", "(Lt x 0)"]);
+
+        let (_, cond_rewrites) = bubbler.find_rewrites(&term_wkld, &sign_preds);
+        let InferredFacts::Rewrites(cond_rewrites) = cond_rewrites else {
+            panic!("Expected rewrites")
+        };
+
+        println!(
+            "=== Discovered conditional rewrites ({}) ===",
+            cond_rewrites.len()
+        );
+        for rw in &cond_rewrites {
+            println!("  {}", rw);
+        }
+
+        // nonneg(x) → abs(x) ≡ x
+        let has_cond_rw = |cond_op: &LLVMLangOp, lhs_op: &LLVMLangOp, rhs_is_var: bool| {
+            cond_rewrites.iter().any(|rw| {
+                let Some(cond) = rw.cond_concrete() else {
+                    return false;
+                };
+                let Term::Call(c, _) = &cond.term else {
+                    return false;
+                };
+                if c != cond_op {
+                    return false;
+                }
+                let lhs = rw.lhs_concrete();
+                let rhs = rw.rhs_concrete();
+                let lhs_ok = matches!(&lhs, Term::Call(op, _) if op == lhs_op);
+                let rhs_ok = if rhs_is_var {
+                    matches!(rhs, Term::Var(_))
+                } else {
+                    matches!(rhs, Term::Call(LLVMLangOp::Neg, _))
+                };
+                lhs_ok && rhs_ok
+            })
+        };
+
+        assert!(
+            has_cond_rw(&LLVMLangOp::Ge, &LLVMLangOp::Abs, true),
+            "Expected nonneg(x) → abs(x) ≡ x; got: {:?}",
+            cond_rewrites
+                .iter()
+                .map(|r| r.to_string())
+                .collect::<Vec<_>>()
         );
         assert!(
-            has_implication(&LLVMLangOp::Lt, &LLVMLangOp::Le),
-            "Expected neg(x) → nonpos(x); got: {:?}",
-            implications.iter().map(|i| i.to_string()).collect::<Vec<_>>()
+            has_cond_rw(&LLVMLangOp::Le, &LLVMLangOp::Abs, false),
+            "Expected nonpos(x) → abs(x) ≡ -x; got: {:?}",
+            cond_rewrites
+                .iter()
+                .map(|r| r.to_string())
+                .collect::<Vec<_>>()
         );
     }
 


### PR DESCRIPTION
The "simplest" analysis that one could reasonably think of is signedness -- if bubbler can't figure out e.g. that `a > 0 && b > 0 --> a * b > 0`, then there's no reason to work on anything more advanced.

This Claude-guided PR contains a bunch of code that's just responsible for guiding inference of signedness. I think some key things that are reminiscent of Chompy stuff:
- We need to implement `&&` axioms e.g. `(a && b) --> a`
- Scheduling is very important to scaling the system. Better rewrites help you prune implication candidates, and better implications help you prune rewrite rules. So you have to figure out what your step 1 is, essentially.

We're not done yet, but I think the path forward involves some subset of the following (roughly in the order that I think you'd do them):
- [ ] Continuing to prune the existing set of rules until we get something that looks like it expresses the canonical set of implications involving signedness
- [ ] Extend the experiment so that we cover not just `Add` and `Mul`, but the remaining operators as well. `Sub` might be interesting because anything involving `(sub a b)` can be rewritten into `(add a (neg b))`. `Min` and `Max` are also monotonic, so it'll also be interesting to see if the current approach needs any tweaks for discovering those implications as well.
- [ ] Write down what we learned so that we can "formalize" the bubbler scheduling philosophy for theory exploration
- [ ] See if this actually helps us prune many Halide handwritten rules